### PR TITLE
Add g:luasyn_nosymboloperator & luaSymbolOperator.

### DIFF
--- a/syntax/lua.vim
+++ b/syntax/lua.vim
@@ -15,7 +15,7 @@ syntax sync fromstart
 
 " Clusters
 syntax cluster luaBase contains=luaComment,luaCommentLong,luaConstant,luaNumber,luaString,luaStringLong,luaBuiltIn
-syntax cluster luaExpr contains=@luaBase,luaTable,luaParen,luaBracket,luaSpecialTable,luaSpecialValue,luaOperator,luaEllipsis,luaComma,luaFunc,luaFuncCall,luaError
+syntax cluster luaExpr contains=@luaBase,luaTable,luaParen,luaBracket,luaSpecialTable,luaSpecialValue,luaOperator,luaSymbolOperator,luaEllipsis,luaComma,luaFunc,luaFuncCall,luaError
 syntax cluster luaStat contains=@luaExpr,luaIfThen,luaBlock,luaLoop,luaGoto,luaLabel,luaLocal,luaStatement,luaSemiCol
 
 syntax match luaNoise /\%(\.\|,\|:\|\;\)/
@@ -26,7 +26,9 @@ syntax region luaParen   transparent matchgroup=luaParens   start='(' end=')' co
 syntax region luaBracket transparent matchgroup=luaBrackets start="\[" end="\]" contains=@luaExpr
 syntax match  luaComma ","
 syntax match  luaSemiCol ";"
-syntax match  luaOperator "[#<>=~^&|*/%+-]\|\.\."
+if !exists('g:luasyn_nosymboloperator')
+  syntax match luaSymbolOperator "[#<>=~^&|*/%+-]\|\.\."
+endi
 syntax match  luaEllipsis "\.\.\."
 
 " Catch errors caused by unbalanced brackets and keywords
@@ -193,6 +195,7 @@ if version >= 508 || !exists("did_lua_syn_inits")
   HiLink luaLabel            Label
   HiLink luaLocal            Type
   HiLink luaNumber           Number
+  HiLink luaSymbolOperator   luaOperator
   HiLink luaOperator         Operator
   HiLink luaRepeat           Repeat
   HiLink luaSemiCol          Delimiter


### PR DESCRIPTION
The option `g:luasyn_nosymboloperator = 1` can be used to completely disable
highlighting of the Lua symbol operators (that is, all operators except
for the keyword operators `and` and `or`).

Even if that option is not set (the default) then the symbol operators will
use their new own highlighting group `luaSymbolOperator` that is linked
to `luaOperator`.