### PR TITLE
Fix bug when using ignorecase with functions named End()

### DIFF
--- a/indent/lua.vim
+++ b/indent/lua.vim
@@ -22,9 +22,9 @@ endif
 
 " Variables -----------------------------------------------{{{1
 
-let s:open_patt = '\%(\<\%(function\|if\|repeat\|do\)\>\|(\|{\)'
-let s:middle_patt = '\<\%(else\|elseif\)\>'
-let s:close_patt = '\%(\<\%(end\|until\)\>\|)\|}\)'
+let s:open_patt = '\C\%(\<\%(function\|if\|repeat\|do\)\>\|(\|{\)'
+let s:middle_patt = '\C\<\%(else\|elseif\)\>'
+let s:close_patt = '\C\%(\<\%(end\|until\)\>\|)\|}\)'
 
 let s:anon_func_start = '\S\+\s*[({].*\<function\s*(.*)\s*$'
 let s:anon_func_end = '\<end\%(\s*[)}]\)\+'

--- a/indent/lua.vim
+++ b/indent/lua.vim
@@ -30,13 +30,13 @@ let s:anon_func_start = '\S\+\s*[({].*\<function\s*(.*)\s*$'
 let s:anon_func_end = '\<end\%(\s*[)}]\)\+'
 
 " Expression used to check whether we should skip a match with searchpair().
-let s:skip_expr = "synIDattr(synID(line('.'),col('.'),1),'name') =~ 'luaComment\\|luaString'"
+let s:skip_expr = "synIDattr(synID(line('.'),col('.'),1),'name') =~# 'luaComment\\|luaString'"
 
 " Auxiliary Functions -------------------------------------{{{1
 
 function s:IsInCommentOrString(lnum, col)
-  return synIDattr(synID(a:lnum, a:col, 1), 'name') =~ 'luaCommentLong\|luaStringLong'
-        \ && !(getline(a:lnum) =~ '^\s*\%(--\)\?\[=*\[') " opening tag is not considered 'in'
+  return synIDattr(synID(a:lnum, a:col, 1), 'name') =~# 'luaCommentLong\|luaStringLong'
+        \ && !(getline(a:lnum) =~# '^\s*\%(--\)\?\[=*\[') " opening tag is not considered 'in'
 endfunction
 
 " Find line above 'lnum' that isn't blank, in a comment or string.
@@ -83,7 +83,7 @@ function GetLuaIndent()
   endif
 
   " special case: call(with, {anon = function() -- should indent only once
-  if num_pairs > 1 && contents_prev =~ s:anon_func_start
+  if num_pairs > 1 && contents_prev =~# s:anon_func_start
     let i = 1
   endif
 
@@ -96,7 +96,7 @@ function GetLuaIndent()
   endif
 
   " special case: end}) -- end of call with anon func should unindent once
-  if num_pairs > 1 && contents_cur =~ s:anon_func_end
+  if num_pairs > 1 && contents_cur =~# s:anon_func_end
     let i = -1
   endif
 


### PR DESCRIPTION
0bda299 fixes bug where user uses ignorecase or smartcase and has functions
named End():

set ignorecase

    function Hi()
        if imgui.Begin() then
            -- ...
        end
        imgui.End()
    end

4b5962d is probably correct, but I don't know how to test it thoroughly or what specific bugs it might fix.