### PR TITLE
Use shiftwidth() instead of &sw to accomodate sw=0

### DIFF
--- a/indent/lua.vim
+++ b/indent/lua.vim
@@ -111,6 +111,6 @@ function GetLuaIndent()
   " restore cursor
   call setpos(".", original_cursor_pos)
 
-  return indent(prev_line) + (&sw * i)
+  return indent(prev_line) + (shiftwidth() * i)
 
 endfunction


### PR DESCRIPTION
> As :h shiftwidth() suggests: This function was introduced with patch 7.3.694 in 2012, everybody should have it by now.

In [my vimrc](https://github.com/muhmuhten/.dotfiles/blob/ebe9eb32dcaa731d117f35c8c39fe7a960cfa598/vim/vimrc#L4), I set sw=0 for the intended semantic "When zero the 'ts' value will be used." Indent scripts directly using &sw then indent everything flush left.

This patch makes the necessary trivial change to use shiftwidth().