### PR TITLE
syntax: Add option to display ~= as Not Equal To

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ keep it disabled).
 - `g:lua_syntax_nosymboloperator` disables highlighting of the Lua symbol
   operators (that is, all operators except for the keyword operators and and
   or).
+- `g:lua_syntax_fancynotequal` enables displaying Lua's `~=` operator with
+  Unicode character `≠`.
 - `g:lua_syntax_nofold` disables code folding. If this option is set, you can
   selectively reenable some folds with `g:lua_syntax_fold_<group>` where
   `<group>` can be table, comment, function, control or string. You can also

--- a/syntax/lua.vim
+++ b/syntax/lua.vim
@@ -11,6 +11,11 @@ if !exists("main_syntax")
   let main_syntax = 'lua'
 endif
 
+if exists('g:lua_syntax_fancynotequal') && !has('conceal')
+  unlet g:lua_syntax_fancynotequal
+endif
+
+
 syntax sync fromstart
 
 function! s:FoldableRegion(tag, name, expr)
@@ -38,7 +43,11 @@ syntax region luaBracket transparent matchgroup=luaBrackets start="\[" end="\]" 
 syntax match  luaComma ","
 syntax match  luaSemiCol ";"
 if !exists('g:lua_syntax_nosymboloperator')
-  syntax match luaSymbolOperator "[#<>=~^&|*/%+-]\|\.\."
+  if exists('g:lua_syntax_fancynotequal')
+    syntax match luaNotEqOperator "\V~=" conceal cchar=≠
+    setlocal conceallevel=2
+  endi
+  syntax match luaSymbolOperator "[#<>=~^&|*/%+-]\|\.\." contains=luaNotEqOperator
 endi
 syntax match  luaEllipsis "\.\.\."
 
@@ -227,6 +236,7 @@ if version >= 508 || !exists("did_lua_syn_inits")
   HiLink luaLocal            Type
   HiLink luaNumber           Number
   HiLink luaSymbolOperator   luaOperator
+  HiLink luaNotEqOperator    luaOperator
   HiLink luaOperator         Operator
   HiLink luaRepeat           Repeat
   HiLink luaSemiCol          Delimiter
@@ -237,6 +247,10 @@ if version >= 508 || !exists("did_lua_syn_inits")
   HiLink luaStringLong       luaString
   HiLink luaStringSpecial    SpecialChar
   HiLink luaErrHand          Exception
+
+  if exists('g:lua_syntax_fancynotequal')
+    hi! link Conceal luaOperator
+  endi
 
   delcommand HiLink
 end


### PR DESCRIPTION
When switching back and forth between Lua and other languages, I
sometimes get confused by Lua's unusual use of the ~= instead of !=.

When using ligature fonts like Fira Code, ~= is displayed with Unicode
Asymptotically Equal To which is *very* wrong.

This change resolves both of these issues by making the ~= operator
display as the mathematically familiar Unicode Not Equal To: ≠

It's disabled by default. Enable with:

  let g:lua_syntax_fancynotequal = 1

It cannot be enabled when using lua_syntax_nosymboloperator.

Tested with Penlight's dir and it everything looked right with and
without lua_syntax_fancynotequal.
https://raw.githubusercontent.com/Tieske/Penlight/master/lua/pl/dir.lua