### PR TITLE
Add support for indenting method chaining

### DIFF
--- a/indent/lua.vim
+++ b/indent/lua.vim
@@ -29,6 +29,8 @@ let s:close_patt = '\C\%(\<\%(end\|until\)\>\|)\|}\)'
 let s:anon_func_start = '\S\+\s*[({].*\<function\s*(.*)\s*$'
 let s:anon_func_end = '\<end\%(\s*[)}]\)\+'
 
+let s:chained_func_call = "^\\v\\s*[:.]\\w+[({\"']"
+
 " Expression used to check whether we should skip a match with searchpair().
 let s:skip_expr = "synIDattr(synID(line('.'),col('.'),1),'name') =~# 'luaComment\\|luaString'"
 
@@ -96,6 +98,16 @@ function GetLuaIndent()
   let num_cur_closed_parens = searchpair('(', '', ')', 'mr', s:skip_expr, v:lnum)
   if num_cur_closed_parens > 0 && contents_cur !~# s:anon_func_end
     let i += 1
+  endif
+
+  " if the current line chains a function call to previous unchained line
+  if contents_prev !~# s:chained_func_call && contents_cur =~# s:chained_func_call
+    let i += 1
+  endif
+
+  " if the current line chains a function call to previous unchained line
+  if contents_prev =~# s:chained_func_call && contents_cur !~# s:chained_func_call
+    let i -= 1
   endif
 
   " special case: call(with, {anon = function() -- should indent only once


### PR DESCRIPTION
Support indenting chained method calls:

```lua
  local colon_out = self.kitchen
    :getContents()
    :getCheese()
    :enjoyCheese(self
      .mouth()
      .open()
      .extendTongue())
    :eatCheese()
    :digestCheese()
```

Also tested on [this real world example](https://gist.github.com/idbrii/c1b06088489d20f27d03663b724ce101) (that gist reflects how indent is applied which differs slightly from the original form) and the screenshot code (unsurprisingly unchanged).