### PR TITLE
Outdent line after an anon func argument

### DIFF
--- a/indent/lua.vim
+++ b/indent/lua.vim
@@ -120,6 +120,11 @@ function GetLuaIndent()
     let i = -1
   endif
 
+  " special case: end}) -- line after end of call w/ anon func should outdent again
+  if i >= 0 && contents_prev =~# s:anon_func_end
+    let i -= 1
+  endif
+
   " restore cursor
   call setpos(".", original_cursor_pos)
 

--- a/test/indent.vader
+++ b/test/indent.vader
@@ -1,0 +1,53 @@
+Before:
+  setlocal expandtab shiftwidth=4 tabstop=4
+
+Given lua (chained functions):
+  if true then
+      local data = self.kitchen
+          :getCheese()
+          :enjoyCheese(self
+          :getHead()
+          :getMouth())
+          end
+
+Do (reindent):
+  gg=G
+
+Expect lua (indented chained functions):
+  if true then
+      local data = self.kitchen
+          :getCheese()
+          :enjoyCheese(self
+              :getHead()
+              :getMouth())
+  end
+
+Given lua (chained anonymous function arguments):
+  if false then
+  local data = self.kitchen
+      :eatCheese({fn = function()
+          return 10
+      end})
+          :digestCheese(function()
+              return 1
+          end)
+
+          self:Func()
+      end
+
+Do (reindent):
+  gg=G
+
+Expect lua (indented chained anonymous function arguments):
+  if false then
+      local data = self.kitchen
+          :eatCheese({fn = function()
+              return 10
+          end})
+          :digestCheese(function()
+              return 1
+          end)
+
+      self:Func()
+  end
+

--- a/test/indent.vader
+++ b/test/indent.vader
@@ -51,3 +51,68 @@ Expect lua (indented chained anonymous function arguments):
       self:Func()
   end
 
+
+Given lua (anonymous function as third argument):
+  local p = self.input:getActiveControls(
+    5,
+    10,
+    function(value)
+          local name_remap = {
+              axis = {
+                  left = "Left Stick",
+              },
+          }
+          return name_remap[value] or value
+      end)
+  print(p)
+
+
+Do (reindent):
+  gg=G
+
+Expect lua (function begin/end line up and body indents):
+  local p = self.input:getActiveControls(
+      5,
+      10,
+      function(value)
+          local name_remap = {
+              axis = {
+                  left = "Left Stick",
+              },
+          }
+          return name_remap[value] or value
+      end)
+  print(p)
+
+
+Do (put first arg on call line, reindent):
+  ggJx=G
+
+Expect lua (function indent matches first newline argument):
+  local p = self.input:getActiveControls(5,
+      10,
+      function(value)
+          local name_remap = {
+              axis = {
+                  left = "Left Stick",
+              },
+          }
+          return name_remap[value] or value
+      end)
+  print(p)
+
+
+Do (put all args on one line, reindent):
+  ggJx3J=G
+
+Expect lua (function indent combines with parens indent):
+  local p = self.input:getActiveControls(5, 10, function(value)
+      local name_remap = {
+          axis = {
+              left = "Left Stick",
+          },
+      }
+      return name_remap[value] or value
+  end)
+  print(p)
+


### PR DESCRIPTION
Fix anonymous function argument causes following line to be incorrectly
indented.

Previously, it would give indentation like this:
```lua
data = self.kitchen
	:digestCheese(function()
		return 1
	end)
	self:Func() -- wrong indentation

data = self.kitchen
	:eatCheese({fn = function()
		return 10
	end})
		:digestCheese() -- wrong indentation
```

Now, it's like this:
```lua
data = self.kitchen
	:digestCheese(function()
		return 1
	end)
self:Func()

data = self.kitchen
	:eatCheese({fn = function()
		return 10
	end})
	:digestCheese()
```

Add [vader.vim](https://github.com/junegunn/vader.vim) tests:

* indented chained functions:
  *    worked before and still works
* indented chained anonymous function arguments:
  *    broken before and now works
* indented non first argument anonymous function:
  *    broken before and now works